### PR TITLE
Added option to passthru request data on auth.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ internals.hawk = function (server, options) {
     var scheme = {
         authenticate: function (request, reply) {
 
+            if (options.passthru){
+                settings.hawk.credentialsFuncData = request;
+            }
+
             Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, function (err, credentials, artifacts) {
 
                 if (!err) {

--- a/test/hawk.js
+++ b/test/hawk.js
@@ -44,7 +44,7 @@ describe('Hawk', function () {
         }
     };
 
-    var getCredentials = function (id, callback) {
+    var getCredentials = function (id, data, callback) {
 
         if (credentials[id]) {
             return callback(credentials[id].err, credentials[id].cred);
@@ -85,6 +85,29 @@ describe('Hawk', function () {
             });
         });
     });
+
+    it('returns a reply on successful auth, using request passthru', function (done) {
+
+        var server = new Hapi.Server();
+        server.pack.register(require('../'), function (err) {
+
+            expect(err).to.not.exist;
+            server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials, passthru: true });
+            server.route({ method: 'POST', path: '/hawk',
+                handler: function (request, reply) { reply('Success'); },
+                config: { auth: 'default' } }
+            );
+
+            var request = { method: 'POST', url: 'http://example.com:8080/hawk', headers: { authorization: hawkHeader('john', '/hawk').field } };
+            server.inject(request, function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result).to.equal('Success');
+                done();
+            });
+        });
+    });
+
 
     it('returns a reply on failed optional auth', function (done) {
 
@@ -160,7 +183,7 @@ describe('Hawk', function () {
                     payload: res.payload
                 };
 
-                getCredentials('john', function (err, cred) {
+                getCredentials('john', null, function (err, cred) {
 
                     var header = Hawk.server.header(cred, authHeader.artifacts, options);
                     expect(header).to.equal(res.headers['server-authorization']);
@@ -195,7 +218,7 @@ describe('Hawk', function () {
                     contentType: res.headers['content-type']
                 };
 
-                getCredentials('john', function (err, cred) {
+                getCredentials('john', null, function (err, cred) {
 
                     var header = Hawk.server.header(cred, authHeader.artifacts, options);
                     expect(header).to.equal(res.headers['server-authorization']);
@@ -231,7 +254,7 @@ describe('Hawk', function () {
                     contentType: res.headers['content-type']
                 };
 
-                getCredentials('john', function (err, cred) {
+                getCredentials('john', null, function (err, cred) {
 
                     authHeader.artifacts.credentials = cred;
                     var header = Hawk.server.header(cred, authHeader.artifacts, options);


### PR DESCRIPTION
This relates to Hawk pull request #121 ( https://github.com/hueniverse/hawk/pull/121 )

We needed a way to pass the full request object through to our authentication functions. This will check if a passthru option is set to true and, if it is, add the full request data to to settings.hawk object. This is similar to the passReqToCallback option in Passport.
