### PR TITLE
Update node 4+, hapi 13+, es6 syntax.  closes #22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 4
+  - "4.0"
+  - "4"
+  - "5"
 
 sudo: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,11 +96,12 @@ internals.hawk = function (server, options) {
 
                 var header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
 
+                console.log('-- FINISH --');
                 // @question
                 // related tests also marked with @question in: test/hawk.js
                 // should this be headers or trailers
                 // addTrailers sometimes in headers. sometimes not.
-                // why did this pass headers before the upgrade to node 4 and hapi 13?
+                // previously, pass headers before the upgrade to node 4 and hapi 13?
 
                 request.raw.res.addTrailers({ 'server-authorization': header });
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,6 @@ internals.hawk = function (server, options) {
 
                 var header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
 
-                console.log('-- FINISH v13 --' + JSON.stringify(header));
                 // @question
                 // related tests also marked with @question in: test/hawk.js
                 // should this be headers or trailers

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,15 @@
+'use strict';
+
 // Load modules
 
-var Boom = require('boom');
-var Hoek = require('hoek');
-var Hawk = require('hawk');
+const Boom = require('boom');
+const Hoek = require('hoek');
+const Hawk = require('hawk');
 
 
 // Declare internals
 
-var internals = {};
+const internals = {};
 
 
 exports.register = function (server, options, next) {
@@ -28,34 +30,34 @@ internals.hawk = function (server, options) {
     Hoek.assert(options, 'Invalid hawk scheme options');
     Hoek.assert(options.getCredentialsFunc, 'Missing required getCredentialsFunc method in hawk scheme configuration');
 
-    var settings = Hoek.clone(options);
+    const settings = Hoek.clone(options);
     settings.hawk = settings.hawk || {};
 
-    var scheme = {
+    const scheme = {
         authenticate: function (request, reply) {
 
-            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, function (err, credentials, artifacts) {
+            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, artifacts) => {
 
                 if (!err) {
 
-                    request.once('peek', function (chunk) {
+                    request.once('peek', (chunk) => {
 
-                        var payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);
+                        const payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);
                         payloadHash.update(chunk);
 
-                        request.on('peek', function (chunk2) {
+                        request.on('peek', (chunk2) => {
 
                             payloadHash.update(chunk2);
                         });
 
-                        request.once('finish', function () {
+                        request.once('finish', () => {
 
                             request.plugins['hapi-auth-hawk'] = { payloadHash: Hawk.crypto.finalizePayloadHash(payloadHash) };
                         });
                     });
                 }
 
-                var result = { credentials: credentials, artifacts: artifacts };
+                const result = { credentials: credentials, artifacts: artifacts };
 
                 if (err) {
                     return reply(err, null, result);
@@ -64,13 +66,13 @@ internals.hawk = function (server, options) {
                 return reply.continue(result);
             });
         },
-        payload: function (request, reply) {
+        payload: (request, reply) => {
 
             if (!request.auth.artifacts.hash) {
                 return reply(Boom.unauthorized(null, 'Hawk'));      // Missing
             }
 
-            var plugin = request.plugins['hapi-auth-hawk'];
+            const plugin = request.plugins['hapi-auth-hawk'];
             if (plugin &&
                 Hawk.server.authenticatePayloadHash(plugin.payloadHash, request.auth.artifacts)) {
 
@@ -79,28 +81,25 @@ internals.hawk = function (server, options) {
 
             return reply(Boom.unauthorized('Payload is invalid'));
         },
-        response: function (request, reply) {
+        response: (request, reply) => {
 
-            var response = request.response;
-            var payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, response.headers['content-type']);
+            const response = request.response;
+            const payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, response.headers['content-type']);
 
             response.header('trailer', 'server-authorization');
             response.header('transfer-encoding', 'chunked');
 
-            response.on('peek', function (chunk) {
+            response.on('peek', (chunk) => {
 
                 payloadHash.update(chunk);
             });
 
-            response.once('finish', function () {
+            response.once('finish', () => {
 
-                var header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
+                const header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
 
-                // @question
-                // related tests also marked with @question in: test/hawk.js
-                // should this be headers or trailers
-                // addTrailers sometimes in headers. sometimes not.
-                // previously, pass headers before the upgrade to node 4 and hapi 13?
+                // Trailers set here.
+                // hapijs/shot handling of trailers differs from version to version.
 
                 request.raw.res.addTrailers({ 'server-authorization': header });
             });
@@ -113,20 +112,20 @@ internals.hawk = function (server, options) {
 };
 
 
-internals.bewit = function (server, options) {
+internals.bewit = (server, options) => {
 
     Hoek.assert(options, 'Invalid bewit scheme options');
     Hoek.assert(options.getCredentialsFunc, 'Missing required getCredentialsFunc method in bewit scheme configuration');
 
-    var settings = Hoek.clone(options);
+    const settings = Hoek.clone(options);
     settings.hawk = settings.hawk || {};
 
-    var scheme = {
-        authenticate: function (request, reply) {
+    const scheme = {
+        authenticate: (request, reply) => {
 
-            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, function (err, credentials, bewit) {
+            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, bewit) => {
 
-                var result = { credentials: credentials, artifacts: bewit };
+                const result = { credentials: credentials, artifacts: bewit };
                 if (err) {
                     return reply(err, null, result);
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,9 @@ internals.hawk = function (server, options) {
 
             response.header('trailer', 'server-authorization');
             response.header('transfer-encoding', 'chunked');
+            // We must not send a content-length header alongside transfer-encoding.
+            // see https://tools.ietf.org/html/rfc7230#section-3.3.3
+            delete response.headers['content-length'];
 
             response.on('peek', function (chunk) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ internals.hawk = (server, options) => {
 
             response.header('trailer', 'server-authorization');
             response.header('transfer-encoding', 'chunked');
+
             // We must not send a content-length header alongside transfer-encoding.
             // see https://tools.ietf.org/html/rfc7230#section-3.3.3
             delete response.headers['content-length'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const Hawk = require('hawk');
 const internals = {};
 
 
-exports.register = function (server, options, next) {
+exports.register = (server, options, next) => {
 
     server.auth.scheme('hawk', internals.hawk);
     server.auth.scheme('bewit', internals.bewit);
@@ -25,7 +25,7 @@ exports.register.attributes = {
 };
 
 
-internals.hawk = function (server, options) {
+internals.hawk = (server, options) => {
 
     Hoek.assert(options, 'Invalid hawk scheme options');
     Hoek.assert(options.getCredentialsFunc, 'Missing required getCredentialsFunc method in hawk scheme configuration');
@@ -34,7 +34,7 @@ internals.hawk = function (server, options) {
     settings.hawk = settings.hawk || {};
 
     const scheme = {
-        authenticate: function (request, reply) {
+        authenticate(request, reply) {
 
             Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, artifacts) => {
 
@@ -66,7 +66,7 @@ internals.hawk = function (server, options) {
                 return reply.continue(result);
             });
         },
-        payload: (request, reply) => {
+        payload(request, reply) {
 
             if (!request.auth.artifacts.hash) {
                 return reply(Boom.unauthorized(null, 'Hawk'));      // Missing
@@ -81,7 +81,7 @@ internals.hawk = function (server, options) {
 
             return reply(Boom.unauthorized('Payload is invalid'));
         },
-        response: (request, reply) => {
+        response(request, reply) {
 
             const response = request.response;
             const payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, response.headers['content-type']);
@@ -121,11 +121,11 @@ internals.bewit = (server, options) => {
     settings.hawk = settings.hawk || {};
 
     const scheme = {
-        authenticate: (request, reply) => {
+        authenticate(request, reply) {
 
-            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, bewit) => {
+            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, creds, bewit) => {
 
-                const result = { credentials: credentials, artifacts: bewit };
+                const result = { credentials: creds, artifacts: bewit };
                 if (err) {
                     return reply(err, null, result);
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ internals.hawk = function (server, options) {
             Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, function (err, credentials, artifacts) {
 
                 if (!err) {
+
                     request.once('peek', function (chunk) {
 
                         var payloadHash = Hawk.crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);
@@ -55,6 +56,7 @@ internals.hawk = function (server, options) {
                 }
 
                 var result = { credentials: credentials, artifacts: artifacts };
+
                 if (err) {
                     return reply(err, null, result);
                 }
@@ -93,6 +95,13 @@ internals.hawk = function (server, options) {
             response.once('finish', function () {
 
                 var header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
+
+                // @question
+                // related tests also marked with @question in: test/hawk.js
+                // should this be headers or trailers
+                // addTrailers sometimes in headers. sometimes not.
+                // why did this pass headers before the upgrade to node 4 and hapi 13?
+
                 request.raw.res.addTrailers({ 'server-authorization': header });
             });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ internals.hawk = function (server, options) {
 
                 var header = Hawk.server.header(request.auth.credentials, request.auth.artifacts, { hash: Hawk.crypto.finalizePayloadHash(payloadHash) });
 
-                console.log('-- FINISH --');
+                console.log('-- FINISH v13 --' + JSON.stringify(header));
                 // @question
                 // related tests also marked with @question in: test/hawk.js
                 // should this be headers or trailers

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ internals.hawk = (server, options) => {
     const scheme = {
         authenticate(request, reply) {
 
-            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, artifacts) => {
+            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, creds, artifacts) => {
 
                 if (!err) {
 
@@ -57,7 +57,7 @@ internals.hawk = (server, options) => {
                     });
                 }
 
-                const result = { credentials: credentials, artifacts: artifacts };
+                const result = { credentials: creds, artifacts: artifacts };
 
                 if (err) {
                     return reply(err, null, result);

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ internals.hawk = (server, options) => {
     const scheme = {
         authenticate(request, reply) {
 
-            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, creds, artifacts) => {
+            Hawk.server.authenticate(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, artifacts) => {
 
                 if (!err) {
 
@@ -57,7 +57,7 @@ internals.hawk = (server, options) => {
                     });
                 }
 
-                const result = { credentials: creds, artifacts: artifacts };
+                const result = { credentials, artifacts };
 
                 if (err) {
                     return reply(err, null, result);
@@ -123,9 +123,10 @@ internals.bewit = (server, options) => {
     const scheme = {
         authenticate(request, reply) {
 
-            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, creds, bewit) => {
+            Hawk.server.authenticateBewit(request.raw.req, settings.getCredentialsFunc, settings.hawk, (err, credentials, artifacts) => {
 
-                const result = { credentials: creds, artifacts: bewit };
+                const result = { credentials, artifacts };
+
                 if (err) {
                     return reply(err, null, result);
                 }
@@ -137,3 +138,4 @@ internals.bewit = (server, options) => {
 
     return scheme;
 };
+

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lab": "8.x.x"
   },
   "scripts": {
-    "test": "lab -r console -t 100 -a code -L -v",
+    "test": "lab -r console -t 100 -a code -L",
     "test-cov-html": "lab -r html -o coverage.html -a code -L"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -12,23 +12,23 @@
     "bewit"
   ],
   "engines": {
-    "node": ">=0.10.33"
+    "node": ">=4.2.6"
   },
   "dependencies": {
-    "boom": "2.x.x",
-    "hoek": "2.x.x",
-    "hawk": "3.x.x"
+    "boom": "3.x.x",
+    "hoek": "3.x.x",
+    "hawk": "4.x.x"
   },
   "peerDependencies": {
-    "hapi": ">=8.x.x"
+    "hapi": ">=13.x.x"
   },
   "devDependencies": {
-    "code": "1.x.x",
-    "hapi": "8.x.x",
-    "lab": "6.x.x"
+    "code": "2.x.x",
+    "hapi": "13.x.x",
+    "lab": "8.x.x"
   },
   "scripts": {
-    "test": "lab -r console -t 100 -a code -L",
+    "test": "lab -r console -t 100 -a code -L -v",
     "test-cov-html": "lab -r html -o coverage.html -a code -L"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-auth-hawk",
   "description": "Hawk authentication plugin",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": "git://github.com/hapijs/hapi-auth-hawk",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bewit"
   ],
   "engines": {
-    "node": ">=4.2.6"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "boom": "3.x.x",

--- a/test/bewit.js
+++ b/test/bewit.js
@@ -59,6 +59,7 @@ describe('bewit scheme', function () {
 
     var server = new Hapi.Server();
     server.connection();
+
     before(function (done) {
 
         server.register(require('../'), function (err) {
@@ -159,15 +160,20 @@ describe('bewit scheme', function () {
 
         var fn = function () {
 
+            // server.route({ method: 'POST',
             server.route({ method: 'POST',
                 path: '/bewitPayload',
                 handler: bewitHandler,
-                config: { auth: { mode: 'required', strategy: 'default', payload: 'required' },
-                    payload: { output: 'stream', parse: false } }
+                config: { 
+                    auth: { mode: 'required', strategy: 'default', payload: 'required' },
+                    payload: { output: 'stream', parse: false } 
+                }
             });
         };
 
-        expect(fn).to.throw('Payload validation can only be required when all strategies support it in path: /bewitPayload');
+        // This relates to: hapi/lib/auth.js
+        // new hapi version removed "path: " from error message.
+        expect(fn).to.throw('Payload validation can only be required when all strategies support it in /bewitPayload');
         done();
     });
 
@@ -183,7 +189,7 @@ describe('bewit scheme', function () {
             });
         };
 
-        expect(fn).to.throw('Payload authentication requires at least one strategy with payload support in path: /bewitPayload');
+        expect(fn).to.throw('Payload authentication requires at least one strategy with payload support in /bewitPayload');
         done();
     });
 

--- a/test/hawk.js
+++ b/test/hawk.js
@@ -80,7 +80,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -108,7 +108,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawkOptional',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -140,8 +140,6 @@ describe('hawk scheme', () => {
 
                 TestStream.prototype._read = function (size) {
 
-                    const self = this;
-
                     if (this.isDone) {
                         return;
                     }
@@ -149,12 +147,12 @@ describe('hawk scheme', () => {
 
                     setTimeout(() => {
 
-                        self.push('hi');
+                        this.push('hi');
                     }, 2);
 
                     setTimeout(() => {
 
-                        self.push(null);
+                        this.push(null);
                     }, 5);
                 };
 
@@ -215,7 +213,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -263,7 +261,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawkValidate',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -293,7 +291,6 @@ describe('hawk scheme', () => {
                         authHeader.artifacts.credentials = cred;
                         const header = Hawk.server.header(cred, authHeader.artifacts, options);
 
-                        // expect(header).to.equal(res.headers['server-authorization']);
                         expect(header).to.equal(res.trailers['server-authorization']);
 
                         server.stop(done);
@@ -313,7 +310,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawkError',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply(new Error());
                     },
@@ -342,7 +339,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -370,7 +367,7 @@ describe('hawk scheme', () => {
                 server.auth.strategy('default', 'hawk', { getCredentialsFunc: getCredentials });
                 server.route({
                     method: 'POST', path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -399,7 +396,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -428,7 +425,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkScope',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -463,7 +460,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawk',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -492,7 +489,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -530,7 +527,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -563,7 +560,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -596,7 +593,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayloadOptional',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -629,7 +626,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayloadOptional',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -661,7 +658,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayloadOptional',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -693,7 +690,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayloadNone',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -725,7 +722,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayloadNone',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -758,7 +755,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkOptionalPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -790,7 +787,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkOptionalPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },
@@ -823,7 +820,7 @@ describe('hawk scheme', () => {
                 server.route({
                     method: 'POST',
                     path: '/hawkPayload',
-                    handler: (request, reply) => {
+                    handler(request, reply) {
 
                         reply('Success');
                     },

--- a/test/hawk.js
+++ b/test/hawk.js
@@ -179,6 +179,8 @@ describe('hawk scheme', function () {
                 // Original, expect(res.headers['server-authorization']).to.contain('Hawk');
                 // Before updating hapi and node res.headers would be set.  After upgrading only trailers is set.
 
+                console.log('-- RESPONSE v13 --' + JSON.stringify(res.headers));
+
                 expect(res.trailers['server-authorization']).to.contain('Hawk');
 
                 var options = {

--- a/test/hawk.js
+++ b/test/hawk.js
@@ -82,8 +82,6 @@ describe('hawk scheme', function () {
             var request = { method: 'POST', url: 'http://example.com:8080/hawk', headers: { authorization: hawkHeader('john', '/hawk').field } };
             server.inject(request, function (res) {
 
-                // console.log('res.headers: ' + JSON.stringify(res.headers));
-                // console.log('res.trailers: ' + JSON.stringify(res.trailers));
                 expect(res.statusCode).to.equal(200);
                 expect(res.result).to.equal('Success');
                 done();
@@ -117,7 +115,7 @@ describe('hawk scheme', function () {
         });
     });
 
-    it('includes authorization header in response when the response is a stream', function (done) {
+    it('includes authorization trailer in response when the response is a stream', function (done) {
 
         var hawkStreamHandler = function (request, reply) {
 
@@ -176,10 +174,6 @@ describe('hawk scheme', function () {
                 expect(res.statusCode).to.equal(200);
 
                 // @question trailers or headers.
-                // Original, expect(res.headers['server-authorization']).to.contain('Hawk');
-                // Before updating hapi and node res.headers would be set.  After upgrading only trailers is set.
-
-                console.log('-- RESPONSE v13 --' + JSON.stringify(res.headers));
 
                 expect(res.trailers['server-authorization']).to.contain('Hawk');
 
@@ -192,8 +186,6 @@ describe('hawk scheme', function () {
                     var header = Hawk.server.header(cred, authHeader.artifacts, options);
 
                     // @question trailers or headers.
-                    // swapped out headers for trailers and got test to pass.
-                    // expect(header).to.equal(res.headers['server-authorization']);
 
                     expect(header).to.equal(res.trailers['server-authorization']);
                     done();
@@ -202,7 +194,7 @@ describe('hawk scheme', function () {
         });
     });
 
-    it('includes valid authorization header in response when the response is text', function (done) {
+    it('includes valid authorization trailer in response when the response is text', function (done) {
 
         var server = new Hapi.Server();
         server.connection();
@@ -250,7 +242,7 @@ describe('hawk scheme', function () {
         });
     });
 
-    it('includes valid authorization header in response when the request fails validation', function (done) {
+    it('includes valid authorization trailer in response when the request fails validation', function (done) {
 
         var server = new Hapi.Server();
         server.connection();
@@ -272,10 +264,6 @@ describe('hawk scheme', function () {
             server.inject(request, function (res) {
 
                 // @question swapped headers to trailers.
-                // expect(res.headers['server-authorization']).to.exist();
-                // expect(res.headers['server-authorization']).to.contain('Hawk');
-                // helpful documentation:
-                // https://nodejs.org/api/http.html#http_response_addtrailers_headers
 
                 expect(res.trailers['server-authorization']).to.exist();
                 expect(res.trailers['server-authorization']).to.contain('Hawk');

--- a/test/hawk.js
+++ b/test/hawk.js
@@ -82,6 +82,8 @@ describe('hawk scheme', function () {
             var request = { method: 'POST', url: 'http://example.com:8080/hawk', headers: { authorization: hawkHeader('john', '/hawk').field } };
             server.inject(request, function (res) {
 
+                // console.log('res.headers: ' + JSON.stringify(res.headers));
+                // console.log('res.trailers: ' + JSON.stringify(res.trailers));
                 expect(res.statusCode).to.equal(200);
                 expect(res.result).to.equal('Success');
                 done();
@@ -175,6 +177,7 @@ describe('hawk scheme', function () {
 
                 // @question trailers or headers.
                 // Original, expect(res.headers['server-authorization']).to.contain('Hawk');
+                // Before updating hapi and node res.headers would be set.  After upgrading only trailers is set.
 
                 expect(res.trailers['server-authorization']).to.contain('Hawk');
 


### PR DESCRIPTION
closes #22 
#### updated dependencies
- **boom** from 2.x.x. to 3.x.x
- **hoek** from 2.x.x. to 3.x.x
- **hawk** from 3.x.x. to 4.x.x
#### update peerDependencies
- **hapi** from 8.x.x. to 13.x.x
#### update devDependencies
- **code** from 1.x.x to 2.x.x
- **hapi** from 8.x.x to 13.x.x
- **lab** from 6.x.x to 8.x.x
#### updated nodejs engine
- >= 4.0.0 required
#### updated to es6 sytax
- satisfies hapi's linting requirements.
#### 100% test coverage
- shot v3 introduced breaking changes to test/hawk.js.
  -  Previously shot 1.x.x did not process trailers.
    and returned trailers in headers.
  -  See shot/lib/index.js v1 has no trailer processing logic.
    Versus v3 does process trailers. shot's  internals.finish() (./lib/index.js)
    contains logic to process headers and trailers. View this file to see differences
    between shot v3 and v1 header and trailer handling. 
  -  changed tests to verify trailers versus headers in previous version.
- hapi v13 handled bewit errors differently than hapi v8 causing the upgrade to to break bewit tests.
   refactored bewit tests to pass. Project is now ready for [internet falconry ](https://github.com/hueniverse/hawk)
- refactored tests' server init logic.
#### My first attempt to contribute to hapi-auth-hawk :-)
