### PR TITLE
Remove content-length header when setting transfer-encoding.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,8 @@ internals.hawk = function (server, options) {
 
             response.header('trailer', 'server-authorization');
             response.header('transfer-encoding', 'chunked');
+            // We must not send a content-length header alongside transfer-encoding.
+            delete response.headers['content-length'];
 
             response.on('peek', function (chunk) {
 


### PR DESCRIPTION
RFC2616 says that the content-length header must not be sent if the transfer-encoding header is present, and a recent security release of node [1] will throw a ParseError on responses that have both headers present.  Since hapi-auth-hawk sets the transfer-encoding header without clearing content-length, these new versions of node will error out when parsing responses from servers that use this plugin.

This PR simply deletes the former header when setting the latter, which seems to be enough in my local testing, but I don't know enough about the nitty-gritty of response handling in Hapi to know whether that's safe in all cases.

[1] https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/